### PR TITLE
Adding license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vo",
   "version": "4.0.2",
   "description": "Vo is a control flow library for minimalists",
+  "license": "MIT",
   "keywords": [
     "control",
     "flow",


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance analysis.